### PR TITLE
Update links

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -8,35 +8,35 @@
         <mkdir dir="${project.source.directory}"/>
         <parallel>
             <get
-                src="https://dist.torproject.org/torbrowser/${torbrowser.version}/torbrowser-install-${torbrowser.version}_en-US.exe"
+            src="https://archive.torproject.org/tor-package-archive/torbrowser/${torbrowser.version}/torbrowser-install-${torbrowser.version}_en-US.exe"
                 dest="${project.source.directory}/torbrowser-install-${torbrowser.version}_en-US.exe"
                 skipexisting="true"/>
             <get
-                src="https://dist.torproject.org/torbrowser/${torbrowser.version}/torbrowser-install-${torbrowser.version}_en-US.exe.asc"
+                src="https://archive.torproject.org/tor-package-archive/torbrowser/${torbrowser.version}/torbrowser-install-${torbrowser.version}_en-US.exe.asc"
                 dest="${project.source.directory}/torbrowser-install-${torbrowser.version}_en-US.exe.asc"
                 skipexisting="true"/>
             <get
-                src="https://dist.torproject.org/torbrowser/${torbrowser.version}/TorBrowser-${torbrowser.version}-osx64_en-US.dmg"
+                src="https://archive.torproject.org/tor-package-archive/torbrowser/${torbrowser.version}/TorBrowser-${torbrowser.version}-osx64_en-US.dmg"
                 dest="${project.source.directory}/TorBrowser-${torbrowser.version}-osx64_en-US.dmg"
                 skipexisting="true"/>
             <get
-                src="https://dist.torproject.org/torbrowser/${torbrowser.version}/TorBrowser-${torbrowser.version}-osx64_en-US.dmg.asc"
+                src="https://archive.torproject.org/tor-package-archive/torbrowser/${torbrowser.version}/TorBrowser-${torbrowser.version}-osx64_en-US.dmg.asc"
                 dest="${project.source.directory}/TorBrowser-${torbrowser.version}-osx64_en-US.dmg.asc"
                 skipexisting="true"/>
             <get
-                src="https://dist.torproject.org/torbrowser/${torbrowser.version}/tor-browser-linux32-${torbrowser.version}_en-US.tar.xz"
+                src="https://archive.torproject.org/tor-package-archive/torbrowser/${torbrowser.version}/tor-browser-linux32-${torbrowser.version}_en-US.tar.xz"
                 dest="${project.source.directory}/tor-browser-linux32-${torbrowser.version}_en-US.tar.xz"
                 skipexisting="true"/>
             <get
-                src="https://dist.torproject.org/torbrowser/${torbrowser.version}/tor-browser-linux32-${torbrowser.version}_en-US.tar.xz.asc"
+                src="https://archive.torproject.org/tor-package-archive/torbrowser/${torbrowser.version}/tor-browser-linux32-${torbrowser.version}_en-US.tar.xz.asc"
                 dest="${project.source.directory}/tor-browser-linux32-${torbrowser.version}_en-US.tar.xz.asc"
                 skipexisting="true"/>
             <get
-                src="https://dist.torproject.org/torbrowser/${torbrowser.version}/tor-browser-linux64-${torbrowser.version}_en-US.tar.xz"
+                src="https://archive.torproject.org/tor-package-archive/torbrowser/${torbrowser.version}/tor-browser-linux64-${torbrowser.version}_en-US.tar.xz"
                 dest="${project.source.directory}/tor-browser-linux64-${torbrowser.version}_en-US.tar.xz"
                 skipexisting="true"/>
             <get
-                src="https://dist.torproject.org/torbrowser/${torbrowser.version}/tor-browser-linux64-${torbrowser.version}_en-US.tar.xz.asc"
+                src="https://archive.torproject.org/tor-package-archive/torbrowser/${torbrowser.version}/tor-browser-linux64-${torbrowser.version}_en-US.tar.xz.asc"
                 dest="${project.source.directory}/tor-browser-linux64-${torbrowser.version}_en-US.tar.xz.asc"
                 skipexisting="true"/>
         </parallel>

--- a/tor-binary-resources/pom.xml
+++ b/tor-binary-resources/pom.xml
@@ -30,19 +30,19 @@
                                 <mkdir dir="${project.source.directory}"/>
                                 <parallel>
                                     <get
-                                        src="https://dist.torproject.org/torbrowser/${torbrowser.version}/tor-browser-windows-i686-portable-${torbrowser.version}.exe"
+                                        src="https://archive.torproject.org/tor-package-archive/torbrowser/${torbrowser.version}/tor-browser-windows-i686-portable-${torbrowser.version}.exe"
                                         dest="${project.source.directory}/tor-browser-windows-i686-portable-${torbrowser.version}.exe"
                                         skipexisting="true"/>
                                     <get
-                                        src="https://dist.torproject.org/torbrowser/${torbrowser.version}/tor-browser-macos-${torbrowser.version}.dmg"
+                                        src="https://archive.torproject.org/tor-package-archive/torbrowser/${torbrowser.version}/tor-browser-macos-${torbrowser.version}.dmg"
                                         dest="${project.source.directory}/tor-browser-macos-${torbrowser.version}.dmg"
                                         skipexisting="true"/>
                                     <get
-                                        src="https://dist.torproject.org/torbrowser/${torbrowser.version}/tor-browser-linux-i686-${torbrowser.version}.tar.xz"
+                                        src="https://archive.torproject.org/tor-package-archive/torbrowser/${torbrowser.version}/tor-browser-linux-i686-${torbrowser.version}.tar.xz"
                                         dest="${project.source.directory}/tor-browser-linux-i686-${torbrowser.version}.tar.xz"
                                         skipexisting="true"/>
                                     <get
-                                        src="https://dist.torproject.org/torbrowser/${torbrowser.version}/tor-browser-linux-x86_64-${torbrowser.version}.tar.xz"
+                                        src="https://archive.torproject.org/tor-package-archive/torbrowser/${torbrowser.version}/tor-browser-linux-x86_64-${torbrowser.version}.tar.xz"
                                         dest="${project.source.directory}/tor-browser-linux-x86_64-${torbrowser.version}.tar.xz"
                                         skipexisting="true"/>
                                 </parallel>


### PR DESCRIPTION
The original links used dist.torproject.org for the binaries. However, the version that was used has now been moved to archive.torproject.org. The links have now been updated.